### PR TITLE
Avoid reacting to hashchange when writing to hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Avoid reacting to hashchange when writing to hash
+
 ## 0.7.1
 
 - Build package


### PR DESCRIPTION
Closes #78.

The root cause of #78 appears to have been that the app was reacting to `hashchange` even when the app was writing to the hash, so a stutter was occurring.