### PR TITLE
Quick fix for branch bug

### DIFF
--- a/src/branch-utils.js
+++ b/src/branch-utils.js
@@ -1,5 +1,86 @@
+import { config as configStore } from './stores';
+
 const branchToken = '{branch}';
 const styleToken = '{style}';
+
+let branchPatterns;
+
+configStore.subscribe(value => ({ branchPatterns } = value));
+
+const findBranchPattern = url => {
+  const isPattern = (url, branchPattern) => {
+    const { pattern, styles } = branchPattern || {};
+    if (!pattern || !styles) return false;
+    const sections = pattern.split(branchToken).filter(Boolean);
+    const knownUrlParts = sections.filter(s => !s.includes(styleToken));
+    const unknownUrlParts = sections.filter(s => s.includes(styleToken));
+
+    return (
+      knownUrlParts.every(part => url.includes(part)) &&
+      unknownUrlParts.every(part =>
+        styles.some(s => url.includes(part.replace(styleToken, s)))
+      )
+    );
+  };
+
+  return branchPatterns.find(p => isPattern(url, p));
+};
+
+const parseBranchUrl = url => {
+  if (!findBranchPattern(url)) return null;
+  const { pattern } = findBranchPattern(url);
+
+  const splitToken = (str, token) => {
+    const arr = str.split(token);
+    for (let i = 0; i < arr.length; i++) {
+      if (i % 2 !== 0) {
+        arr.splice(i, 0, token);
+      }
+    }
+    return arr;
+  };
+
+  let patternParts = splitToken(pattern, branchToken);
+  patternParts = patternParts
+    .map(section => {
+      let nextSection = section;
+      if (section.includes(styleToken)) {
+        nextSection = splitToken(section, styleToken);
+      }
+      return nextSection;
+    })
+    .flat()
+    .filter(Boolean);
+
+  let urlTokenValues = [url];
+  // This will leave us with an array of all parts of url that are token values
+  patternParts.forEach(part => {
+    urlTokenValues = urlTokenValues
+      .map(section => section.split(part))
+      .flat()
+      .filter(Boolean);
+  });
+
+  const tokenOrder = patternParts.filter(
+    item => item.startsWith('{') && item.endsWith('}')
+  );
+
+  if (tokenOrder.length !== urlTokenValues.length) {
+    console.error('Trying to parse a url that does not fit the pattern.');
+  }
+
+  const parsed = tokenOrder.reduce((acc, token, i) => {
+    let key = token.replace('{', '').replace('}', '');
+    // Change key name to have better variable
+    if (key === 'style') {
+      key = 'styleId';
+    }
+    acc[key] = urlTokenValues[i];
+    return acc;
+  }, {});
+
+  return parsed;
+};
 
 const createBranchUrl = (pattern, branchName, selectedStyle) => {
   return pattern
@@ -7,4 +88,4 @@ const createBranchUrl = (pattern, branchName, selectedStyle) => {
     .replace(styleToken, selectedStyle);
 };
 
-export { createBranchUrl };
+export { createBranchUrl, parseBranchUrl };

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -165,12 +165,10 @@
 
   const handleSelect = val => {
     selected = val;
-
     const { dropdownType } = val;
     switch (dropdownType) {
       case 'preset': {
         const { type, url } = val;
-
         if (type === 'google') {
           handleMapStyleUpdate(val);
           break;
@@ -185,7 +183,6 @@
         } else {
           textInput = '';
         }
-
         break;
       }
       case 'custom': {

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -22,6 +22,7 @@
   let branchPatterns;
 
   // Temporary fix
+  // TODO: This is not a good long term solution
   let branchId;
 
   stylePresetsStore.subscribe(value => (stylePresets = value));

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -21,6 +21,9 @@
   let stylePresets;
   let branchPatterns;
 
+  // Temporary fix
+  let branchId;
+
   stylePresetsStore.subscribe(value => (stylePresets = value));
   configStore.subscribe(value => ({ branchPatterns } = value));
 
@@ -165,10 +168,13 @@
 
   const handleSelect = val => {
     selected = val;
+
     const { dropdownType } = val;
     switch (dropdownType) {
       case 'preset': {
         const { type, url } = val;
+        branchId = undefined;
+
         if (type === 'google') {
           handleMapStyleUpdate(val);
           break;
@@ -178,14 +184,18 @@
         break;
       }
       case 'branch': {
+        branchId = val.id;
+
         if (textInput && textInput === branch) {
           submitUrl();
         } else {
           textInput = '';
         }
+
         break;
       }
       case 'custom': {
+        branchId = undefined;
         textInput = url;
         break;
       }
@@ -242,6 +252,7 @@
       textInput = '';
     } else if (branch) {
       selected = {
+        id: branchId,
         name,
         dropdownType: 'branch',
         url,

--- a/src/components/MapStyleInput.svelte
+++ b/src/components/MapStyleInput.svelte
@@ -5,7 +5,7 @@
     stylePresets as stylePresetsStore,
     config as configStore,
   } from '../stores';
-  import { createBranchUrl } from '../branch-utils';
+  import { createBranchUrl, parseBranchUrl } from '../branch-utils';
   import { shortcut } from '../shortcut';
   import { fetchUrl } from '../fetch-url';
 
@@ -20,10 +20,6 @@
 
   let stylePresets;
   let branchPatterns;
-
-  // Temporary fix
-  // TODO: This is not a good long term solution
-  let branchId;
 
   stylePresetsStore.subscribe(value => (stylePresets = value));
   configStore.subscribe(value => ({ branchPatterns } = value));
@@ -174,7 +170,6 @@
     switch (dropdownType) {
       case 'preset': {
         const { type, url } = val;
-        branchId = undefined;
 
         if (type === 'google') {
           handleMapStyleUpdate(val);
@@ -185,8 +180,6 @@
         break;
       }
       case 'branch': {
-        branchId = val.id;
-
         if (textInput && textInput === branch) {
           submitUrl();
         } else {
@@ -196,7 +189,6 @@
         break;
       }
       case 'custom': {
-        branchId = undefined;
         textInput = url;
         break;
       }
@@ -252,8 +244,9 @@
       selected = { ...stylePresetOption, dropdownType: 'preset' };
       textInput = '';
     } else if (branch) {
+      const { styleId } = parseBranchUrl(url);
       selected = {
-        id: branchId,
+        id: styleId,
         name,
         dropdownType: 'branch',
         url,


### PR DESCRIPTION
Part of https://github.com/stamen/maperture/issues/86

> One downside here is I don't believe the id gets set on the initial load so we'd have to handle that. I think we should find a fix that fixes this short-term but consider a refactor to make this component easier to follow.

This implements a quick fix for the bug in #86 by bringing back `parseBranchUrl` from https://github.com/stamen/maperture/pull/21. Ultimately we decided to delete `parseBranchUrl` at the time because it wasn't necessary and was potentially over-complicated. This resolves the initial load problem mentioned with the solution proposed in #86.

Per conversation with @ebrelsford we'll want to actually do a better refactoring of `MapStyleInput` for a cleaner fix and hopefully a more legible file as a followup to this PR. We can close #86 on refactor.